### PR TITLE
added getSearchParameters to index

### DIFF
--- a/packages/node-fhir-server-core/src/index.js
+++ b/packages/node-fhir-server-core/src/index.js
@@ -1,3 +1,4 @@
+const { getSearchParameters } = require('./server/utils/params.utils');
 const { resolveSchema } = require('./server/utils/schema.utils');
 const ServerError = require('./server/utils/server.error');
 const winston = require('./server/winston.js');
@@ -32,6 +33,11 @@ module.exports = {
    * @description Export function to support easier loading of classes
    */
   resolveSchema,
+
+  /**
+   * @description Export function to support easier lookup of search parameters
+   */
+  getSearchParameters,
 
   /**
    * @description Export logger to allow for customization and easy access to


### PR DESCRIPTION
# Summary
The getSearchParameters function is now exported from src/index.js

## New behavior
When perusing src/index.js you should now see the getSearchParameters function exported

## Code changes
exported the getSearchParameters function from src/index.js

# Testing guidance
- Ensure that the getSearchParameters function is exported from index.js
- Ensure that the getSearchParameters function is imported into index.js from the correct location
- Try adding a new file called `test.js` to the packages directory of the monorepo, and copy in this code: `const { getSearchParameters } = require('./node-fhir-server-core/src');

console.log(getSearchParameters('Patient', '4_0_0', null, null));`

Now run the code using`node test.js > output.json` from the packages directory and ensure that the contents of the output.json file match the search params listed [here](https://www.hl7.org/fhir/searchparameter-registry.html) for Patient. I did a simple cmd+f for 'patient' on that page and checked against each of the params that popped up.
